### PR TITLE
Remove "." from sanitizedPaths

### DIFF
--- a/src/ParentWidget.js
+++ b/src/ParentWidget.js
@@ -43,22 +43,7 @@ const Option = (props) => {
   );
 };
 
-export const sanitizePath = (path) => {
-  const replacement = '-';
-  const sanitizedPath = slugify(path.toLowerCase(), replacement);
-
-  // Remove any doubled or leading/trailing replacement characters (that were added in the sanitizers).
-  const doubleReplacement = new RegExp(`(?:${replacement})+`, 'g');
-  const trailingReplacement = new RegExp(`${replacement}$`);
-  const leadingReplacement = new RegExp(`^${replacement}`);
-
-  const normalizedPath = sanitizedPath
-    .replace(doubleReplacement, replacement)
-    .replace(leadingReplacement, '')
-    .replace(trailingReplacement, '');
-
-  return normalizedPath;
-};
+export const sanitizePath = (path) => slugify(path, { replacement: '-', lower: true, remove: /\./ });
 
 export class ParentControl extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Problem:
If the title of an entry contains a ".", the path becomes invalid.

Solution:
Removing all "."s in the path using slugify resolves this problem.

Furthermore the following changes got made to simplify the code of sanitizePath:
- Slugify automatically removes leading, trailing or doubled replacement chars, so doing it explicitly is just a no-op.
- Also slugify has an option for converting to lower case.